### PR TITLE
Savvy Integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,13 @@ add_definitions(-DVERSION="${PROJECT_VERSION}" -DUSER="${USER}" -DDATE="${DATE}"
 
 find_package(ZLIB REQUIRED)
 find_library(STATGEN_LIBRARY StatGen)
+find_package(savvy REQUIRED)
 add_executable(MetaMinimac2
         src/Main.cpp
         src/MyVariables.h src/MarkovParameters.h src/simplex.h
         src/MetaMinimac.h src/MetaMinimac.cpp
         src/HaplotypeSet.h src/HaplotypeSet.cpp
         src/MarkovModel.h src/MarkovModel.cpp)
-target_link_libraries(MetaMinimac2 ${STATGEN_LIBRARY} ${ZLIB_LIBRARIES})
+target_link_libraries(MetaMinimac2 savvy ${STATGEN_LIBRARY} ${ZLIB_LIBRARIES})
 
 install(TARGETS MetaMinimac2 RUNTIME DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,6 @@ execute_process(COMMAND whoami OUTPUT_VARIABLE USER OUTPUT_STRIP_TRAILING_WHITES
 
 add_definitions(-DVERSION="${PROJECT_VERSION}" -DUSER="${USER}" -DDATE="${DATE}")
 
-find_package(ZLIB REQUIRED)
-find_library(STATGEN_LIBRARY StatGen)
 find_package(savvy REQUIRED)
 add_executable(MetaMinimac2
         src/Main.cpp
@@ -16,6 +14,6 @@ add_executable(MetaMinimac2
         src/MetaMinimac.h src/MetaMinimac.cpp
         src/HaplotypeSet.h src/HaplotypeSet.cpp
         src/MarkovModel.h src/MarkovModel.cpp)
-target_link_libraries(MetaMinimac2 savvy ${STATGEN_LIBRARY} ${ZLIB_LIBRARIES})
+target_link_libraries(MetaMinimac2 savvy)
 
 install(TARGETS MetaMinimac2 RUNTIME DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -13,31 +13,29 @@ bash install.sh
 The first step is to impute _**pre-phased**_ target haplotypes against reference panels separately using [Minimac4](https://github.com/statgen/Minimac4) with `--meta` option on, which will generate a `.empiricalDose.vcf.gz` file (which is required for MetaMinimac2) in addition to the `.dose.vcf.gz` file. Please see http://genome.sph.umich.edu/wiki/Minimac4 for detailed documentation for Minimac4.
 
 ```bash
-minimac4 --refHaps refPanelA.m3vcf \
-         --haps targetStudy.vcf \
-         --prefix PanelA.imputed \
-         --meta
+minimac4 refPanelA.m3vcf targetStudy.vcf \
+         --output PanelA.dose.vcf.gz \
+         --empirical-output PanelA.empiricalDose.vcf.gz
          
-minimac4 --refHaps refPanelB.m3vcf \
-         --haps targetStudy.vcf \
-         --prefix PanelB.imputed \
-         --meta
+minimac4 refPanelB.m3vcf targetStudy.vcf \
+         --output PanelB.dose.vcf.gz \
+         --empirical-output PanelB.empiricalDose.vcf.gz
 ```
 
 The second step is to integrate the imputed results using MetaMinimac2.
 
 ```bash
-MetaMinimac2 -i PanelA.imputed:PanelB.imputed -o A_B.meta.testrun
+MetaMinimac2 Panel{A,B}.empiricalDose.vcf.gz Panel{A,B}.dose.vcf.gz -o A_B.meta.testrun
 ```
 
 ## Options
 ```
 -i, --input  <prefix1:prefix2 ...>  (Required) Colon-separated prefixes of input data to meta-impute
 -o, --output <prefix>               (Required) Output prefix [MetaMinimac.Output.Prefix]
+-O, --outputFormat <fmt>            Output file format (vcf, vcf.gz, bcf, ubcf, sav, or usav) [vcf.gz]
 -f, --format <string>               Comma-separated output FORMAT tags [GT,DS,HDS]
 -p, --skipPhasingCheck              OFF by default. If ON, program will skip phasing consistency check before analysis. 
 -s, --skipInfo                      OFF by default. If ON, the INFO fields are removed from the output file
--n, --nobgzip                       OFF by default. If ON, output files will NOT be bgzipped
 -w, --weight                        OFF by default. If ON, weights will be saved in [MetaMinimac.Output.Prefix].metaWeights(.gz)
 -l, --log                           OFF by default. If ON, log will be written to $prefix.logfile
 -h, --help                          OFF by default. If ON, detailed documentation on options and usage will be displayed

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,7 @@
 
 rm -rf cget/ release-build/ install.log
 echo -e "Installing Dependencies - Libstatgen ..."
+cget ignore xz
 cget install -f requirements.txt &> install.log
 mkdir release-build
 cd release-build/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-statgen/libStatGen --cmake dep/libstatgen.cmake
+statgen/savvy@af1bf44b5c9be693f38c8e62a24d4ea38f3ac4a7

--- a/src/HaplotypeSet.cpp
+++ b/src/HaplotypeSet.cpp
@@ -1,5 +1,5 @@
 #include "HaplotypeSet.h"
-#include "assert.h"
+#include <cassert>
 
 #include <savvy/reader.hpp>
 
@@ -281,17 +281,10 @@ void HaplotypeSet::LoadLooVariant(const std::vector<std::int8_t>& gt, const std:
 
 bool HaplotypeSet::doesExistFile(string filename)
 {
-    IFILE ifs = ifopen(filename.c_str(), "r");
+    std::ifstream ifs(filename);
     if (ifs)
-    {
-        ifclose(ifs);
         return true;
-    }
-    else
-    {
-        ifclose(ifs);
-        return false;
-    }
+    return false;
 }
 
 bool HaplotypeSet::CheckSuffixFile(string prefix, const char* suffix, string &FinalName)

--- a/src/HaplotypeSet.cpp
+++ b/src/HaplotypeSet.cpp
@@ -15,8 +15,8 @@ bool HaplotypeSet::LoadSampleNames(std::string empDoseFN, std::string doseFN)
     int tempNoSamples=numSamples;
     vector<string> tempindividualName=individualName;
     vector<int> tempSampleNoHaplotypes=SampleNoHaplotypes;
-    GetSampleInformation(EmpDoseFileName);
-    if(!CheckSampleConsistency(tempNoSamples,tempindividualName,tempSampleNoHaplotypes,DoseFileName,EmpDoseFileName)) return false;
+    if (!GetSampleInformation(EmpDoseFileName)) return false;
+    if (!CheckSampleConsistency(tempNoSamples,tempindividualName,tempSampleNoHaplotypes,DoseFileName,EmpDoseFileName)) return false;
 
     return true;
 
@@ -267,7 +267,7 @@ void HaplotypeSet::LoadCurrentGT(savvy::variant & rec)
 
 void HaplotypeSet::LoadLooVariant(const std::vector<std::int8_t>& gt, const std::vector<float>& lds, int loonumReadRecords, int StartSamId, int EndSamId)
 {
-    assert(gt.size() == numActualHaps);
+    assert(gt.size() >= numActualHaps);
     assert(gt.size() == lds.size());
     int ploidy = numActualHaps / numSamples;
     int start_i = StartSamId * ploidy;

--- a/src/HaplotypeSet.h
+++ b/src/HaplotypeSet.h
@@ -36,7 +36,6 @@ class HaplotypeSet
 public:
 
     // File Name Variables
-    String InfilePrefix;
     string DoseFileName;
     string EmpDoseFileName;
 
@@ -76,7 +75,7 @@ public:
     void        ClearEmpVariantList                     ();
     void        LoadCurrentGT                           (savvy::variant &ThisGenotype);
     void        LoadLooVariant                          (const std::vector<std::int8_t>& gt, const std::vector<float>& lds,int loonumReadRecords, int StartSamId, int EndSamId);
-    bool        LoadSampleNames                         (string prefix);
+    bool        LoadSampleNames                         (std::string empDoseFN, std::string doseFN);
     bool        doesExistFile                           (string filename);
 
     void        LoadData                                (int VariantId, savvy::variant &ThisGenotype);

--- a/src/HaplotypeSet.h
+++ b/src/HaplotypeSet.h
@@ -5,6 +5,8 @@
 #include "VcfHeader.h"
 #include "assert.h"
 
+#include <savvy/site_info.hpp>
+
 using namespace std;
 
 class variant
@@ -72,12 +74,12 @@ public:
     bool        GetSampleInformationfromHDS             (string filename);
     void        LoadEmpVariantList                      ();
     void        ClearEmpVariantList                     ();
-    void        LoadCurrentGT                           (VcfRecordGenotype &ThisGenotype);
-    void        LoadLooVariant                          (VcfRecordGenotype &ThisGenotype,int loonumReadRecords, int StartSamId, int EndSamId);
+    void        LoadCurrentGT                           (savvy::variant &ThisGenotype);
+    void        LoadLooVariant                          (const std::vector<std::int8_t>& gt, const std::vector<float>& lds,int loonumReadRecords, int StartSamId, int EndSamId);
     bool        LoadSampleNames                         (string prefix);
     bool        doesExistFile                           (string filename);
 
-    void        LoadData                                (int VariantId, VcfRecordGenotype &ThisGenotype, int StartSamId, int EndSamId);
+    void        LoadData                                (int VariantId, savvy::variant &ThisGenotype);
     void        GetData                                 (int VariantId);
     void        ClearBuffer                             ();
 };

--- a/src/HaplotypeSet.h
+++ b/src/HaplotypeSet.h
@@ -1,9 +1,8 @@
 #ifndef METAM_HAPLOTYPESET_H
 #define METAM_HAPLOTYPESET_H
 
-#include "VcfFileReader.h"
-#include "VcfHeader.h"
-#include "assert.h"
+#include <map>
+#include <cassert>
 
 #include <savvy/site_info.hpp>
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -1,5 +1,4 @@
 #include <getopt.h>
-#include "Parameters.h"
 #include "MetaMinimac.h"
 #include <unistd.h>
 
@@ -59,7 +58,7 @@ int main(int argc, char ** argv)
     }
 
     if (remaining_arg_count)
-        myAnalysis.myUserVariables.inputFiles.Clear();
+        myAnalysis.myUserVariables.inputFiles.clear();
 
     for (int i = 0; i < remaining_arg_count / 2; ++i)
         myAnalysis.myUserVariables.empInputFiles.emplace_back(argv[optind + i]);
@@ -72,21 +71,20 @@ int main(int argc, char ** argv)
 
     FILE *LogFile=NULL;
     if(myAnalysis.myUserVariables.log)
-        LogFile=freopen(myAnalysis.myUserVariables.outfile +".logfile","w",stdout);
+        LogFile=freopen((myAnalysis.myUserVariables.outfile +".logfile").c_str(),"w",stdout);
     dup2(fileno(stdout), fileno(stderr));
 
     MetaMinimacVersion();
     myAnalysis.myUserVariables.Status();
 
-    String compStatus;
-    String MySuccessStatus="Error";
+    std::string compStatus;
+    std::string MySuccessStatus="Error";
 
     MySuccessStatus = myAnalysis.Analyze();
 
     if(MySuccessStatus!="Success")
     {
         compStatus=MySuccessStatus;
-        PhoneHome::completionStatus(compStatus.c_str());
         return(-1);
     }
 
@@ -103,7 +101,6 @@ int main(int argc, char ** argv)
     cout<<"\n Thank You for using MetaMinimac2 !!! "<<endl<<endl;
 
     compStatus="Success";
-    PhoneHome::completionStatus(compStatus.c_str());
 
     return 0;
 }

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -51,6 +51,22 @@ int main(int argc, char ** argv)
         return(-1);
     }
 
+    int remaining_arg_count = argc - optind;
+    if (remaining_arg_count % 2)
+    {
+        std::cout << "Error: both dosage and empirical dosage files must be passed as input for each reference panel" << std::endl;
+        return(-1);
+    }
+
+    if (remaining_arg_count)
+        myAnalysis.myUserVariables.inputFiles.Clear();
+
+    for (int i = 0; i < remaining_arg_count / 2; ++i)
+        myAnalysis.myUserVariables.empInputFiles.emplace_back(argv[optind + i]);
+
+    for (int i = remaining_arg_count / 2; i < remaining_arg_count; ++i)
+        myAnalysis.myUserVariables.doseInputFiles.emplace_back(argv[optind + i]);
+
     int start_time = time(0);
     myAnalysis.myUserVariables.CreateCommandLine(argc,argv);
 
@@ -109,10 +125,10 @@ void helpFile()
 {
     MetaMinimacVersion();
     printf( "\n About   : Combine GWAS data imputed against different panels  \n");
-    printf( " Usage   : MetaMinimac2 [options] \n");
+    printf( " Usage   : MetaMinimac2 [options] empirical_dose_files... dose_files...  \n");
     printf( "\n");
     printf( " Options :\n");
-    printf( "   -i, --input  <prefix1:prefix2 ...>  Colon-separated prefixes of input data to meta-impute.\n");
+    //printf( "   -i, --input  <prefix1:prefix2 ...>  Colon-separated prefixes of input data to meta-impute.\n");
     printf( "   -o, --output <prefix>               Output prefix [MetaMinimac.Output] \n");
     printf( "   -f, --format <string>               Comma-separated FORMAT tags [GT,DS,HDS]\n");
 //    printf( "   -v, --vcfBuffer <int>               Maximum number of samples processed at a time [200] \n");

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -18,7 +18,7 @@ int main(int argc, char ** argv)
                     {"vcfBuffer",required_argument,NULL,'v'},
                     {"format",required_argument,NULL,'f'},
                     {"skipInfo",no_argument,NULL,'s'},
-                    {"nobgzip",no_argument,NULL,'n'},
+                    {"outputFormat",required_argument,NULL,'O'},
                     {"log",no_argument,NULL,'l'},
                     {"weight",no_argument,NULL,'w'},
                     {"skipPhasingCheck",no_argument,NULL,'p'},
@@ -26,15 +26,15 @@ int main(int argc, char ** argv)
                     {NULL,0,NULL,0}
             };
 
-    while ((c = getopt_long(argc, argv, "i:o:v:f:snlwh",loptions,NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "i:o:O:v:f:slwh",loptions,NULL)) >= 0)
     {
         switch (c) {
-            case 'i': myAnalysis.myUserVariables.inputFiles = optarg; break;
-            case 'o': myAnalysis.myUserVariables.outfile = optarg; break;
+            case 'i': myAnalysis.myUserVariables.inputPrefixes = optarg; break;
+            case 'o': myAnalysis.myUserVariables.outPrefix = optarg; break;
             case 'w': myAnalysis.myUserVariables.debug=true; break;
             case 'f': myAnalysis.myUserVariables.formatString = optarg; break;
             case 's': myAnalysis.myUserVariables.infoDetails = false; break;
-            case 'n': myAnalysis.myUserVariables.nobgzip=true; break;
+            case 'O': myAnalysis.myUserVariables.outFileExtension = optarg; break;
             case 'v': myAnalysis.myUserVariables.VcfBuffer=atoi(optarg); break;
             case 'p': myAnalysis.myUserVariables.hapcheck=false; break;
             case 'h': help=true; break;
@@ -58,7 +58,15 @@ int main(int argc, char ** argv)
     }
 
     if (remaining_arg_count)
-        myAnalysis.myUserVariables.inputFiles.clear();
+        myAnalysis.myUserVariables.inputPrefixes.clear();
+
+    if (std::strncmp(myAnalysis.myUserVariables.outFileExtension.c_str(), "vcf", 3) != 0 &&
+        myAnalysis.myUserVariables.outFileExtension != "bcf" && myAnalysis.myUserVariables.outFileExtension != "ubcf" &&
+        myAnalysis.myUserVariables.outFileExtension != "sav" && myAnalysis.myUserVariables.outFileExtension != "usav")
+    {
+        std::cout << "Error: unsupported --outputFormat" << std::endl;
+        return(-1);
+    }
 
     for (int i = 0; i < remaining_arg_count / 2; ++i)
         myAnalysis.myUserVariables.empInputFiles.emplace_back(argv[optind + i]);
@@ -71,7 +79,7 @@ int main(int argc, char ** argv)
 
     FILE *LogFile=NULL;
     if(myAnalysis.myUserVariables.log)
-        LogFile=freopen((myAnalysis.myUserVariables.outfile +".logfile").c_str(),"w",stdout);
+        LogFile=freopen((myAnalysis.myUserVariables.outPrefix +".logfile").c_str(),"w",stdout);
     dup2(fileno(stdout), fileno(stderr));
 
     MetaMinimacVersion();
@@ -127,11 +135,11 @@ void helpFile()
     printf( " Options :\n");
     //printf( "   -i, --input  <prefix1:prefix2 ...>  Colon-separated prefixes of input data to meta-impute.\n");
     printf( "   -o, --output <prefix>               Output prefix [MetaMinimac.Output] \n");
+    printf( "   -O, --outputFormat <fmt>           Output file format (vcf, vcf.gz, bcf, ubcf, sav, or usav) [vcf.gz] \n");
     printf( "   -f, --format <string>               Comma-separated FORMAT tags [GT,DS,HDS]\n");
 //    printf( "   -v, --vcfBuffer <int>               Maximum number of samples processed at a time [200] \n");
     printf( "   -p, --skipPhasingCheck              If OFF (by default and highly recommended), program will check phasing consistency before analysis.\n");
     printf( "   -s, --skipInfo                      If ON, the INFO fields are removed from the output file.\n");
-    printf( "   -n, --nobgzip                       If ON, output files will NOT be bgzipped.\n");
     printf( "   -w, --weight                        If ON, weights will be saved in $prefix.metaWeights(.gz)\n");
     printf( "   -l, --log                           If ON, log will be written to $prefix.logfile. \n");
     printf( "   -h, --help                          If ON, detailed help on options and usage. \n");

--- a/src/MetaMinimac.cpp
+++ b/src/MetaMinimac.cpp
@@ -65,30 +65,35 @@ String MetaMinimac::Analyze()
 bool MetaMinimac::ParseInputVCFFiles()
 {
 
-    InPrefixList.clear();
-    size_t pos = 0;
-    std::string delimiter(myUserVariables.FileDelimiter) ;
-    std::string token;
-    int Count=0;
-    string tempName=myUserVariables.inputFiles.c_str();
-    while ((pos = tempName.find(delimiter)) != std::string::npos)
+    if (myUserVariables.inputFiles.Length())
     {
-        token = tempName.substr(0, pos);
-        InPrefixList.push_back(token.c_str());
-        tempName.erase(0, pos + delimiter.length());
-        Count++;
+        size_t pos = 0;
+        std::string delimiter(myUserVariables.FileDelimiter) ;
+        std::string token;
+        int Count=0;
+        string tempName=myUserVariables.inputFiles.c_str();
+        while ((pos = tempName.find(delimiter)) != std::string::npos)
+        {
+            token = tempName.substr(0, pos);
+            myUserVariables.empInputFiles.emplace_back(token + ".empiricalDose.vcf.gz");
+            myUserVariables.doseInputFiles.emplace_back(token + ".dose.vcf.gz");
+            tempName.erase(0, pos + delimiter.length());
+            Count++;
+        }
+
+        myUserVariables.empInputFiles.emplace_back(tempName + ".empiricalDose.vcf.gz");
+        myUserVariables.doseInputFiles.emplace_back(tempName + ".dose.vcf.gz");
     }
-    InPrefixList.push_back(tempName.c_str());
 
 
-    NoInPrefix=(int)InPrefixList.size();
+    NoInPrefix = myUserVariables.empInputFiles.size();
     InputData.clear();
     InputData.resize(NoInPrefix);
 
     cout<<endl<<  " Number of Studies : "<<NoInPrefix<<endl;
     for(int i=0;i<NoInPrefix;i++)
     {
-        cout<<  " -- Study "<<i+1<<" Prefix : "<<InPrefixList[i]<<endl;
+        cout<<  " -- Study "<<i+1<<" Prefix : "<<myUserVariables.empInputFiles[i]<<endl;
     }
 
 
@@ -115,7 +120,7 @@ bool MetaMinimac::CheckSampleNameCompatibility()
     {
         // First, check if dose file and empiricalDose file exist
         // Second, check if sample names are consistent between dose file and empiricalDose file
-        if(!InputData[i].LoadSampleNames(InPrefixList[i].c_str()))
+        if(!InputData[i].LoadSampleNames(myUserVariables.empInputFiles[i], myUserVariables.doseInputFiles[i]))
             return false;
 
         // Check if sample names are consistent with InputData[0]

--- a/src/MetaMinimac.cpp
+++ b/src/MetaMinimac.cpp
@@ -1015,7 +1015,7 @@ void MetaMinimac::CreateMetaImputedData(int VariantId)
     }
     else
     {
-        CurrentMetaImputedDosage.resize(2*NoSamples);
+        CurrentMetaImputedDosage.resize(2*NoSamples, savvy::typed_value::end_of_vector_value<float>());
         for (int j=0; j<CurrentVariant->NoStudiesHasVariant; j++)
         {
             int index = CurrentVariant->StudiesHasVariant[j];

--- a/src/MetaMinimac.cpp
+++ b/src/MetaMinimac.cpp
@@ -12,7 +12,7 @@ using namespace std;
 
 const int MAXBP = 999999999;
 
-String MetaMinimac::Analyze()
+std::string MetaMinimac::Analyze()
 {
     if(!myUserVariables.CheckValidity()) return "Command.Line.Error";
 
@@ -65,7 +65,7 @@ String MetaMinimac::Analyze()
 bool MetaMinimac::ParseInputVCFFiles()
 {
 
-    if (myUserVariables.inputFiles.Length())
+    if (myUserVariables.inputFiles.size())
     {
         size_t pos = 0;
         std::string delimiter(myUserVariables.FileDelimiter) ;
@@ -796,7 +796,7 @@ void MetaMinimac::OutputAllWeights(const std::string& out_file_path)
 
 }
 
-String MetaMinimac::PerformFinalAnalysis()
+std::string MetaMinimac::PerformFinalAnalysis()
 {
     cout << endl;
     cout << " ------------------------------------------------------------------------------" << endl;

--- a/src/MetaMinimac.h
+++ b/src/MetaMinimac.h
@@ -51,7 +51,7 @@ public:
 
     // Output files
     std::unique_ptr<savvy::writer> metaDoseOut;
-    IFILE vcfweightpartial;
+    std::unique_ptr<savvy::writer> metaWeightOut;
     IFILE vcfsnppartial, vcfrsqpartial;
     IFILE metaWeight;
     char *WeightPrintStringPointer;
@@ -122,15 +122,14 @@ public:
     void UpdateOneStepLeft(int SampleInBatch);
     void UpdateOneStepRight(int SampleInBatch);
     void OutputWeights();
-    void OutputPartialWeights();
-    void OutputAllWeights();
+    void OutputAllWeights(const std::string& out_file_path);
 
     String PerformFinalAnalysis();
     bool InitiateWeightsFromRecord();
     void ReadCurrentWeights();
     void CopyCurrentWeightsToPreviousWeights();
     void UpdateWeights();
-    void AppendtoMainWeightsFile();
+    bool AppendtoMainWeightsFile();
 
     void MetaImputeCurrentBuffer();
     void ClearCurrentBuffer();
@@ -138,8 +137,8 @@ public:
     void CreateMetaImputedData(int VariantId);
     void MetaImpute(int Sample);
     void SetMetaImputedData(savvy::variant& out_var);
-    void PrintMetaWeight();
-    void PrintWeightVariantInfo();
+    void SetMetaWeightVecs(std::vector<std::vector<float>>& wt_vecs);
+    void SetWeightVariantInfo(savvy::variant& dest);
 
     void CreateInfo(savvy::variant& rec);
     void PrintWeightForHaplotype(int haploId);

--- a/src/MetaMinimac.h
+++ b/src/MetaMinimac.h
@@ -51,16 +51,8 @@ public:
 
     // Output files
     std::unique_ptr<savvy::writer> metaDoseOut;
-    std::unique_ptr<savvy::writer> metaWeightOut;
-    IFILE vcfsnppartial, vcfrsqpartial;
-    IFILE metaWeight;
-    char *WeightPrintStringPointer;
-    char *RsqPrintStringPointer;
-    char *SnpPrintStringPointer;
-    int WeightPrintStringPointerLength, RsqPrintStringPointerLength, SnpPrintStringPointerLength;
     int batchNo;
     const int BinScalar = 1000;
-    vector<IFILE> vcfrsqpartialList;
 
     variant* CurrentVariant;
     int PrevBp, CurrBp;
@@ -100,7 +92,6 @@ public:
     void CloseStreamInputDosageFiles();
     void CloseStreamInputWeightFiles();
     bool OpenStreamOutputDosageFiles();
-    bool OpenStreamOutputWeightFiles();
 
     bool LoadEmpVariantInfo();
     void FindCommonGenotypedVariants();
@@ -141,9 +132,6 @@ public:
     void SetWeightVariantInfo(savvy::variant& dest);
 
     void CreateInfo(savvy::variant& rec);
-    void PrintWeightForHaplotype(int haploId);
-    void PrintDiploidWeightForSample(int sampleId);
-    void PrintHaploidWeightForSample(int sampleId);
     void summary()
     {
         for (int i=0; i<NoInPrefix; i++)

--- a/src/MetaMinimac.h
+++ b/src/MetaMinimac.h
@@ -5,6 +5,9 @@
 #include "HaplotypeSet.h"
 
 #include <savvy/reader.hpp>
+#include <savvy/writer.hpp>
+
+#include <memory>
 
 using namespace std;
 
@@ -47,15 +50,16 @@ public:
     int NoCommonVariantsProcessed;
 
     // Output files
-    IFILE vcfdosepartial, vcfweightpartial;
+    std::unique_ptr<savvy::writer> metaDoseOut;
+    IFILE vcfweightpartial;
     IFILE vcfsnppartial, vcfrsqpartial;
     IFILE metaWeight;
-    char *VcfPrintStringPointer;
     char *WeightPrintStringPointer;
     char *RsqPrintStringPointer;
     char *SnpPrintStringPointer;
-    int VcfPrintStringPointerLength, WeightPrintStringPointerLength, RsqPrintStringPointerLength, SnpPrintStringPointerLength;
+    int WeightPrintStringPointerLength, RsqPrintStringPointerLength, SnpPrintStringPointerLength;
     int batchNo;
+    const int BinScalar = 1000;
     vector<IFILE> vcfrsqpartialList;
 
     variant* CurrentVariant;
@@ -63,6 +67,9 @@ public:
     vector<vector<double>> *PrevWeights;
     vector<vector<double>> *CurrWeights;
     vector<float> CurrentMetaImputedDosage;
+    savvy::compressed_vector<float> sparse_dosages_;
+    savvy::compressed_vector<std::int8_t> sparse_gt_;
+    std::vector<float> dense_float_vec_;
 
     float CurrentHapDosageSum, CurrentHapDosageSumSq;
 
@@ -130,14 +137,11 @@ public:
     void ReadCurrentDosageData();
     void CreateMetaImputedData(int VariantId);
     void MetaImpute(int Sample);
-    void PrintMetaImputedData();
+    void SetMetaImputedData(savvy::variant& out_var);
     void PrintMetaWeight();
-    void PrintVariantInfo();
     void PrintWeightVariantInfo();
 
-    string CreateInfo();
-    void PrintDiploidDosage(float &x, float &y);
-    void PrintHaploidDosage(float &x);
+    void CreateInfo(savvy::variant& rec);
     void PrintWeightForHaplotype(int haploId);
     void PrintDiploidWeightForSample(int sampleId);
     void PrintHaploidWeightForSample(int sampleId);

--- a/src/MetaMinimac.h
+++ b/src/MetaMinimac.h
@@ -4,6 +4,8 @@
 #include "MyVariables.h"
 #include "HaplotypeSet.h"
 
+#include <savvy/reader.hpp>
+
 using namespace std;
 
 void logitTransform(vector<double> &From,vector<double> &To);
@@ -22,8 +24,8 @@ public:
     int NoVariants, NoCommonTypedVariants;
 
     // Variables for input dosage file stream and records
-    vector<VcfFileReader*> InputDosageStream;
-    vector<VcfRecord*> CurrentRecordFromStudy;
+    vector<savvy::reader*> InputDosageStream;
+    vector<savvy::variant*> CurrentRecordFromStudy;
     vector<int> StudiesHasVariant;
     int CurrentFirstVariantBp;
     int NoStudiesHasVariant;
@@ -31,8 +33,8 @@ public:
     vector<HaplotypeSet> InputData;
 
     // Variables for input weight file stream and records
-    VcfFileReader* InputWeightStream;
-    VcfRecord* CurrentRecordFromWeight;
+    savvy::reader* InputWeightStream;
+    savvy::variant* CurrentRecordFromWeight;
     vector<vector<float>> WeightsFromCurrentRecord, WeightsFromPreviousRecord;
 
     // Process Part of Samples each time
@@ -98,7 +100,7 @@ public:
     void FindCommonGenotypedVariants();
     bool CheckPhasingConsistency();
     void FindCurrentMinimumPosition();
-    int IsVariantEqual(VcfRecord &Rec1, VcfRecord &Rec2);
+    int IsVariantEqual(savvy::variant &Rec1, savvy::variant &Rec2);
     void UpdateCurrentRecords();
 
     void LoadLooDosage();

--- a/src/MetaMinimac.h
+++ b/src/MetaMinimac.h
@@ -14,7 +14,6 @@ class MetaMinimac
 {
 public:
     UserVariables myUserVariables;
-    vector<String> InPrefixList;
     int NoInPrefix;
     string finChromosome;
 

--- a/src/MetaMinimac.h
+++ b/src/MetaMinimac.h
@@ -82,7 +82,7 @@ public:
 
 
 
-    String Analyze();
+    std::string Analyze();
 
     bool ParseInputVCFFiles();
     bool CheckSampleNameCompatibility();
@@ -115,7 +115,7 @@ public:
     void OutputWeights();
     void OutputAllWeights(const std::string& out_file_path);
 
-    String PerformFinalAnalysis();
+    std::string PerformFinalAnalysis();
     bool InitiateWeightsFromRecord();
     void ReadCurrentWeights();
     void CopyCurrentWeightsToPreviousWeights();

--- a/src/MyVariables.h
+++ b/src/MyVariables.h
@@ -1,23 +1,26 @@
 #ifndef METAM_MYVARIABLES_H
 #define METAM_MYVARIABLES_H
 
-#include "StringBasics.h"
+#include <string>
+#include <cstring>
+#include <vector>
+#include <iostream>
 
 using namespace std;
 
 class UserVariables
 {
 public:
-    String inputFiles;
+    std::string inputFiles;
     std::vector<std::string> empInputFiles;
     std::vector<std::string> doseInputFiles;
-    String outfile;
-    String FileDelimiter;
-    String formatString;
+    std::string outfile;
+    std::string FileDelimiter;
+    std::string formatString;
     bool debug;
     int PrintBuffer, VcfBuffer;
     bool infoDetails;
-    String formatStringForVCF;
+    std::string formatStringForVCF;
     bool GT, DS, HDS, GP, SD;
     bool gzip, nobgzip;
     bool log;
@@ -74,12 +77,12 @@ public:
 
 
         char MyCommandLine[len];
-        strcpy(MyCommandLine,argv[0]);
+        std::strcpy(MyCommandLine,argv[0]);
 
         for (int i=1; i<argc; i++)
         {
-            strcat(MyCommandLine, " ");
-            strcat(MyCommandLine, argv[i]);
+            std::strcat(MyCommandLine, " ");
+            std::strcat(MyCommandLine, argv[i]);
         }
         CommandLine=MyCommandLine;
     }

--- a/src/MyVariables.h
+++ b/src/MyVariables.h
@@ -5,16 +5,17 @@
 #include <cstring>
 #include <vector>
 #include <iostream>
+#include <savvy/file.hpp>
 
 using namespace std;
 
 class UserVariables
 {
 public:
-    std::string inputFiles;
+    std::string inputPrefixes;
     std::vector<std::string> empInputFiles;
     std::vector<std::string> doseInputFiles;
-    std::string outfile;
+    std::string outPrefix;
     std::string FileDelimiter;
     std::string formatString;
     bool debug;
@@ -22,7 +23,7 @@ public:
     bool infoDetails;
     std::string formatStringForVCF;
     bool GT, DS, HDS, GP, SD;
-    bool gzip, nobgzip;
+    std::string outFileExtension;
     bool log;
 
     // check phasing consistency
@@ -32,8 +33,8 @@ public:
 
     UserVariables()
     {
-        inputFiles = "";
-        outfile = "MetaMinimac.Output";
+        inputPrefixes = "";
+        outPrefix = "MetaMinimac.Output";
         formatString = "GT,DS,HDS";
         debug=false;
         FileDelimiter=":";
@@ -46,8 +47,7 @@ public:
         HDS=false;
         SD=false;
         debug=false;
-        gzip = true;
-        nobgzip = false;
+        outFileExtension = "vcf.gz";
         VcfBuffer = 1000;
         log = false;
         hapcheck = true;
@@ -56,12 +56,12 @@ public:
     void Status()
     {
         cout << " Command Line Options: " << endl;
-        printf( "      --input [%s],\n", inputFiles.c_str());
-        printf( "      --output [%s],\n", outfile.c_str());
+        printf( "      --input [%s],\n", inputPrefixes.c_str());
+        printf( "      --output [%s],\n", outPrefix.c_str());
+        printf( "      --outputFormat  %s,\n", outFileExtension.c_str());
         printf( "      --format [%s],\n", formatString.c_str());
         printf( "      --skipPhasingCheck %s,\n", hapcheck?"[OFF]":"[ON]");
         printf( "      --skipInfo %s,\n", infoDetails?"[OFF]":"[ON]");
-        printf( "      --nobgzip  %s,\n", nobgzip?"[ON]":"[OFF]");
         printf( "      --weight   %s,\n", debug?"[ON]":"[OFF]");
         printf( "      --log      %s.", log?"[ON]":"[OFF]");
         printf("\n\n");
@@ -155,12 +155,7 @@ public:
             colonIndex=true;
         }
 
-
-        if(nobgzip)
-            gzip=false;
-
-
-        if (inputFiles == "" && empInputFiles.empty())
+        if (inputPrefixes == "" && empInputFiles.empty())
         {
             cout<< " Missing -i [--input], a required parameter.\n\n";
             cout<< " Try -h [--help] for usage ...\n\n";
@@ -186,7 +181,23 @@ public:
         }
 
         return true;
-    };
+    }
+
+    int outCompressionLevel() const
+    {
+      if (outFileExtension == "vcf.gz" || outFileExtension == "bcf" || outFileExtension == "sav")
+          return 6;
+      return 0;
+    }
+
+    savvy::file::format outFileFormat() const
+    {
+      if (outFileExtension == "bcf" || outFileExtension == "ubcf")
+          return savvy::file::format::bcf;
+      else if (outFileExtension == "sav" || outFileExtension == "usav")
+          return savvy::file::format::sav;
+      return savvy::file::format::vcf;
+    }
 };
 
 #endif //METAM_MYVARIABLES_H

--- a/src/MyVariables.h
+++ b/src/MyVariables.h
@@ -9,6 +9,8 @@ class UserVariables
 {
 public:
     String inputFiles;
+    std::vector<std::string> empInputFiles;
+    std::vector<std::string> doseInputFiles;
     String outfile;
     String FileDelimiter;
     String formatString;
@@ -155,9 +157,17 @@ public:
             gzip=false;
 
 
-        if (inputFiles == "")
+        if (inputFiles == "" && empInputFiles.empty())
         {
             cout<< " Missing -i [--input], a required parameter.\n\n";
+            cout<< " Try -h [--help] for usage ...\n\n";
+            cout<< " Program Exiting ...\n\n";
+            return false;
+        }
+
+        if (!empInputFiles.empty() && empInputFiles.size() != doseInputFiles.size())
+        {
+            cout<< " Missing input files.\n\n";
             cout<< " Try -h [--help] for usage ...\n\n";
             cout<< " Program Exiting ...\n\n";
             return false;


### PR DESCRIPTION
This adds full support for Minimac v4.1 output. Specifically, Minimac 4.1 allows for output encoded as VCF, BCF, or SAV. It also deprecates output prefixes in favor of full output file paths. These changes to Minimac v4.1 conflict with the MetatMinimac2 expectation that input files are encode as VCF and have `{empiricalD,d}ose.vcf.gz` suffixes.

Changes:
* libStatGen was replaced with Savvy
* `-i <prefix_A:prefix_B>` was deprecated in favor of  unnamed arguments `prefix_{A,B}.empiricalDose.vcf.gz prefix_{A,B}.dose.vcf.gz`
* `--nobgzip` was replaced with `--outputFormat`

The `--output` prefix behavior has been left unchanged. But I recommend against using prefixes as this prevents piping output to downstream processes and makes it more laborious to write workflows, like Snakemake, that use file based dependencies.

Suggestions:
* Default meta dosage output to stdout
* Change `--output` to specify full output file path of meta dosages
* Remove `--log` and use stderr for log messages so that users can  use  `2>` to control log output
* Change `--weight` to `--weight <path/to/weigh/file.vcf.gz>`